### PR TITLE
Improve coordinate table styling

### DIFF
--- a/src/components/CoordsPanel.js
+++ b/src/components/CoordsPanel.js
@@ -16,7 +16,7 @@ const CoordsPanel = (props) => {
           <td>{coord.lon}</td>
           <td>{coord.lat}</td>
           <td>
-            <button onClick={()=>props.removeCoord(coord.id)}>X</button>
+            <button className='removeCoord' onClick={()=>props.removeCoord(coord.id)}>X</button>
           </td>
         </tr>
       );
@@ -50,13 +50,13 @@ const CoordsPanel = (props) => {
       <Card>
         <Card.Header>Coordinate Options</Card.Header>
         <Card.Body>
-          <Table striped bordered hover size="sm">
+          <Table striped bordered size="sm">
             <thead>
               <tr>
-                <th>#</th>
+                <th style={{width: '5%'}}>#</th>
                 <th>Longitude</th>
                 <th>Latitude</th>
-                <th></th>
+                <th style={{width: '5%', borderColor: 'transparent'}}></th>
               </tr>
             </thead>
             <tbody>

--- a/src/components/scss/main.scss
+++ b/src/components/scss/main.scss
@@ -31,3 +31,13 @@ textarea {
 button {
     margin-right: 0.5rem;
 }
+
+button.removeCoord {
+    background-color: transparent;
+    border: none;
+    font-weight: bold;
+}
+
+table {
+    text-align: center;
+}


### PR DESCRIPTION
## Background
I added some css to clean up the coordinate table appearance. The row number and remove button column widths have been minimized and text centered so that the focus is now on the lat/lon data.  

## Checks
- [X] I've tested the relevant changes from a user POV.
